### PR TITLE
Bump datamodel-code-generator to >=0.44.0 for Python 3.14 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ codegen = [
     "typer>=0.15.0",
     "click>=8.0.0",
     "pyyaml",
-    "datamodel-code-generator[http]>=0.26.4",
+    "datamodel-code-generator[http]>=0.44.0",
     "black",
 ]
 amqp = ["aio-pika"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.10, <3.15"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "aio-pika"
@@ -102,7 +106,7 @@ requires-dist = [
     { name = "aio-pika", marker = "extra == 'amqp'" },
     { name = "black", marker = "extra == 'codegen'" },
     { name = "click", marker = "extra == 'codegen'", specifier = ">=8.0.0" },
-    { name = "datamodel-code-generator", extras = ["http"], marker = "extra == 'codegen'", specifier = ">=0.26.4" },
+    { name = "datamodel-code-generator", extras = ["http"], marker = "extra == 'codegen'", specifier = ">=0.44.0" },
     { name = "jinja2", marker = "extra == 'codegen'", specifier = ">=3.1.4" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pytz" },
@@ -199,7 +203,7 @@ wheels = [
 
 [[package]]
 name = "datamodel-code-generator"
-version = "0.33.0"
+version = "0.56.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete" },
@@ -208,14 +212,13 @@ dependencies = [
     { name = "inflect" },
     { name = "isort" },
     { name = "jinja2" },
-    { name = "packaging" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "tomli", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/a0/3f81c5c0c31d6f25f459e370e04553810f096e5dbd3cf7eda2a67709cd78/datamodel_code_generator-0.33.0.tar.gz", hash = "sha256:7635ef788201d69bd3e98ba88ce6afe479400dc2737fe9d5e21f87408f352c08", size = 458695, upload-time = "2025-08-14T13:50:36.965Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/7d/7fc2bb3d8946ca45851da3f23497a2c6e252e92558ccbd89d609cf1e13d4/datamodel_code_generator-0.56.0.tar.gz", hash = "sha256:e7c003fb5421b890aabe12f66ae65b57198b04cfe1da7c40810798020835b3a8", size = 837708, upload-time = "2026-04-04T09:46:19.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/d0/acd7a19dad4dc4118d2b6ba06df9a4a3725729e91fa3f2c63a765d4e7d44/datamodel_code_generator-0.33.0-py3-none-any.whl", hash = "sha256:e229264aa612b2d5bb4901bcd6c520a799ae0d5c19262577a0f876eb48afaaa3", size = 121148, upload-time = "2025-08-14T13:50:35.306Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/3a/7f169ffc7a2d69a4f9158b1ac083f685b7f4a1a8a1db5d1e4abbb4e741b7/datamodel_code_generator-0.56.0-py3-none-any.whl", hash = "sha256:a0559683fbe90cdf2ce9b6637e3adae3e3a8056a8d0516df581d486e2834ead2", size = 256545, upload-time = "2026-04-04T09:46:17.582Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bumped `datamodel-code-generator` minimum from `>=0.26.4` to `>=0.44.0`
- `datamodel-code-generator` 0.33.0 (previously resolved) has a `PythonVersion` enum that only goes up to 3.13, causing `ValueError: '3.14' is not a valid PythonVersion` on import when running under Python 3.14
- Version 0.44.0 adds `PY_314 = "3.14"` to the enum

## Test Plan
Python 3.14 CI test should now pass collection and execution.